### PR TITLE
Ignore build artifacts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Simple React Calculator 
+
+## Automated dependency updates
+
+This asks GitHub to run
+["dependabot"](https://docs.github.com/en/code-security/dependabot)
+periodically over the repo code base.
+Dependabot is a key tool to ensure that your code dependencies are up to date,
+especially for security concerns.
+
+Dependabot will file PRs for your project when it finds updates, and suggest
+how to update your package files.
+
+See [`.github/dependabot.yml`] to configure.
+Presently it is set to check daily.


### PR DESCRIPTION
First PR!

This is a simple one: ignore build artifacts.
When I run `npm run build`, it creates dirs that are _not_ part of source control. A good git citizen keeps a `.gitignore` file so that contributors do not accidentally commit these.